### PR TITLE
ESLTIMING-33 - Set env var so that correct XDC file gets included for PGP4 timing

### DIFF
--- a/firmware/targets/shared_config.mk
+++ b/firmware/targets/shared_config.mk
@@ -1,6 +1,9 @@
 # Define Firmware Version: v1.2.0.0
 export PRJ_VERSION = 0x01020000
 
+#Use PGP4 Timing
+export INCLUDE_PGP4_6G = 1
+
 # Define release
 ifndef RELEASE
 export RELEASE = lcls2_epix_hr_pcie


### PR DESCRIPTION
The makefile was missing
```
export INCLUDE_PGP4_6G = 1
```
which tells ruckus to use the Pgp4Timing.xdc file.

The Pgp2bTiming.xdc file was being loaded instead, resulting in incorrect timing constraints being applied. This is what caused the issues with the timing feedback link described in ESLTIMING-33.